### PR TITLE
Fix #10: Gtk.TextView.get_iter_at_location use is broken 

### DIFF
--- a/activity.py
+++ b/activity.py
@@ -12,6 +12,8 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
+import gi
+gi.require_version('Gtk','3.0')
 from gi.repository import Gtk
 from gi.repository import GObject
 from gettext import gettext as _

--- a/infoslicer/widgets/Editable_Textbox.py
+++ b/infoslicer/widgets/Editable_Textbox.py
@@ -59,7 +59,7 @@ class Editable_Textbox( Textbox ):
         click_coords = self.window_to_buffer_coords(Gtk.TextWindowType.TEXT, x, y)
         mouseClickPositionIter = self.get_iter_at_location(click_coords[0], click_coords[1])
         if Gtk.check_version(3, 19, 8) is None:
-            if not mouseClickPositionIter:
+            if not mouseClickPositionIter[0]:
                 return False
 
             mouseClickPositionIter = mouseClickPositionIter[1]

--- a/infoslicer/widgets/Editable_Textbox.py
+++ b/infoslicer/widgets/Editable_Textbox.py
@@ -58,6 +58,12 @@ class Editable_Textbox( Textbox ):
     def get_mouse_iter(self, x, y):
         click_coords = self.window_to_buffer_coords(Gtk.TextWindowType.TEXT, x, y)
         mouseClickPositionIter = self.get_iter_at_location(click_coords[0], click_coords[1])
+        if Gtk.check_version(3, 19, 8) is None:
+            if not mouseClickPositionIter:
+                return False
+
+            mouseClickPositionIter = mouseClickPositionIter[1]
+
         return mouseClickPositionIter
     
     def set_mode(self, snapto):

--- a/infoslicer/widgets/Textbox.py
+++ b/infoslicer/widgets/Textbox.py
@@ -54,4 +54,10 @@ class Textbox( Gtk.TextView ):
         # Convenience method to get the iter in the buffer of x, y coords.
         click_coords = self.window_to_buffer_coords(Gtk.TextWindowType.TEXT, x, y)
         mouseClickPositionIter = self.get_iter_at_location(click_coords[0], click_coords[1])
+        if Gtk.check_version(3, 19, 8) is None:
+            if not mouseClickPositionIter:
+                return False
+
+            mouseClickPositionIter = mouseClickPositionIter[1]
+
         return mouseClickPositionIter

--- a/infoslicer/widgets/Textbox.py
+++ b/infoslicer/widgets/Textbox.py
@@ -55,7 +55,7 @@ class Textbox( Gtk.TextView ):
         click_coords = self.window_to_buffer_coords(Gtk.TextWindowType.TEXT, x, y)
         mouseClickPositionIter = self.get_iter_at_location(click_coords[0], click_coords[1])
         if Gtk.check_version(3, 19, 8) is None:
-            if not mouseClickPositionIter:
+            if not mouseClickPositionIter[0]:
                 return False
 
             mouseClickPositionIter = mouseClickPositionIter[1]


### PR DESCRIPTION
**Fixed in this PR:** Gtk.TextView.get_iter_at_location was modified for Gtk 3.19.9 and above. This PR fixes the same while ensuring backward compatibility.

Gtk.TextView.get_iter_at_location, now returns a tuple of the form - **(bool, iter: Gtk.TextIter)**
**Reference:** [Here](https://lazka.github.io/pgi-docs/Gtk-3.0/classes/TextView.html#Gtk.TextView.get_iter_at_location)


Tested.

@quozl Kindly review
