### PR TITLE
Port from GObject to GLib

### DIFF
--- a/activity.py
+++ b/activity.py
@@ -17,10 +17,10 @@
 import gi
 gi.require_version('Gtk','3.0')
 from gi.repository import Gtk
-from gi.repository import GObject
+from gi.repository import GLib
 from gettext import gettext as _
 
-GObject.threads_init()
+GLib.threads_init()
 
 from sugar3.graphics.toolbutton import ToolButton
 from sugar3.graphics.toggletoolbutton import ToggleToolButton

--- a/book.py
+++ b/book.py
@@ -18,6 +18,7 @@ import os
 import uuid
 import logging
 from gi.repository import GObject
+from gi.repository import GLib
 import json
 import shutil
 import zipfile
@@ -71,9 +72,9 @@ class Book(GObject.GObject):
 
         self._article.uid = entry['uid']
         self._article.article_title = title
-        GObject.idle_add(self._emit_article_selected)
+        GLib.idle_add(self._emit_article_selected)
 
-    article = GObject.property(type=object,
+    article = GObject.Property(type=object,
             getter=get_article, setter=set_article)
 
     def _emit_article_selected(self):

--- a/bookview.py
+++ b/bookview.py
@@ -18,6 +18,7 @@ import os
 from gi.repository import Gtk
 import logging
 from gi.repository import GObject
+from gi.repository import GLib
 from gettext import gettext as _
 
 from sugar3.graphics.toolbutton import ToolButton
@@ -33,7 +34,7 @@ class BookView(Gtk.VBox):
     def sync(self):
         if not self._changing:
             return
-        GObject.source_remove(self._changing)
+        GLib.source_remove(self._changing)
         index, column = self.tree.get_cursor()
         self._cursor_changed(index)
 
@@ -187,7 +188,7 @@ class BookView(Gtk.VBox):
             return find_name(list, prefix, uniq+1)
 
         if self._changing:
-            GObject.source_remove(self._changing)
+            GLib.source_remove(self._changing)
             self._changing = None
 
         name = find_name(self.store, _('New article'), 0)
@@ -203,7 +204,7 @@ class BookView(Gtk.VBox):
             return
 
         if self._changing:
-            GObject.source_remove(self._changing)
+            GLib.source_remove(self._changing)
             self._changing = None
 
         index = path.get_indices()[0]
@@ -261,12 +262,12 @@ class BookView(Gtk.VBox):
 
     def _cursor_changed_cb(self, widget):
         if self._changing:
-            GObject.source_remove(self._changing)
+            GLib.source_remove(self._changing)
 
         index, column = self.tree.get_cursor()
 
         if index != None:
-            self._changing = GObject.timeout_add(500, self._cursor_changed,
+            self._changing = GLib.timeout_add(500, self._cursor_changed,
                     index)
 
     def _cursor_changed(self, index):

--- a/edit.py
+++ b/edit.py
@@ -17,6 +17,7 @@
 from gi.repository import Gtk
 from gi.repository import Gdk
 from gi.repository import GObject
+from gi.repository import GLib
 from gettext import gettext as _
 
 from sugar3.graphics.toolbutton import ToolButton
@@ -117,7 +118,7 @@ class ToolbarBuilder():
     def _toggle_image_chooser(self, widget):
         # self._old_cursor = self.edit.get_window().get_cursor()
         # self.edit.get_window().set_cursor(Gdk.Cursor.new(Gdk.CursorType.WATCH))
-        GObject.idle_add(self.__image_chooser)
+        GLib.idle_add(self.__image_chooser)
 
     def __image_chooser(self):
         chooser = ObjectChooser(what_filter=mime.GENERIC_TYPE_IMAGE)
@@ -133,7 +134,7 @@ class ToolbarBuilder():
     def _toggle_text_chooser(self, widget):
         # self._old_cursor = self.edit.get_window().get_cursor()
         # self.edit.get_window().set_cursor(Gdk.Cursor.new(Gdk.CursorType.WATCH))
-        GObject.idle_add(self.__text_chooser)
+        GLib.idle_add(self.__text_chooser)
 
     def __text_chooser(self):
         chooser = ObjectChooser(what_filter=mime.GENERIC_TYPE_TEXT)


### PR DESCRIPTION
### Explanation
This PR ports GObject based methods to GLib. 

### Reason
Thousands of PyGIDeprecationWarning occur in shell.log and activity logs when using PyGObject development releases, because of our use of GObject instead of GLib for certain methods.

### Test result
No error related to the port from GObject to GLib. 
```
tonadev@TDPC:~/Documents/Work/OpenSource/code_in/sugarlabs/infoslicer$ sugar-activity

(sugar-activity:5708): Gtk-WARNING **: 13:11:20.483: Theme parsing error: gtk-widgets.css:16:32: The style property GtkExpander:expander-size is deprecated and shouldn't be used anymore. It will be removed in a future version

(sugar-activity:5708): Gtk-WARNING **: 13:11:20.483: Theme parsing error: gtk-widgets.css:17:35: The style property GtkExpander:expander-spacing is deprecated and shouldn't be used anymore. It will be removed in a future version
1540753881.566323 WARNING root: icon_size is deprecated. Use pixel_size instead.
1540753881.567308 WARNING root: icon_size is deprecated. Use pixel_size instead.

```
