### PR TITLE
Fixing misbehaviour of the content box

### DIFF
--- a/infoslicer/widgets/Editable_Textbox.py
+++ b/infoslicer/widgets/Editable_Textbox.py
@@ -38,7 +38,7 @@ class Editable_Textbox( Textbox ):
         self.ignore_snap_self = True
         self.drag_source = False
         self.edited = False
-        self.set_property("left-margin", 5)
+        self.set_property("left-margin", 2)
 
         logging.debug('########### Editable_Textbox.drag_dest_set')
         self.drag_dest_set_target_list(Gtk.TargetList.new([]))

--- a/infoslicer/widgets/Textbox.py
+++ b/infoslicer/widgets/Textbox.py
@@ -28,7 +28,7 @@ class Textbox( Gtk.TextView ):
         self.set_editable(False)  
         self.modify_font(Pango.FontDescription('arial 9'))
         self.article = None
-        self.set_property("left-margin", 5)
+        self.set_property("left-margin", 2)
         
     def set_article(self, article):
         self.article = article


### PR DESCRIPTION
The content box used to extended beyond the left border.One of the possible
reasons might would have been larger margin.

Decreasing the left margin value luckily fixed the issue.

Fixes https://github.com/sugarlabs/infoslicer/issues/21